### PR TITLE
update single layout for image-less pages like commission

### DIFF
--- a/themes/Malara/layouts/_default/single.html
+++ b/themes/Malara/layouts/_default/single.html
@@ -1,6 +1,7 @@
 {{ define "content" }}
 <section id="single">
     {{ with .Params }}
+    {{ if .image }}
     <div class="picture">
         <img src="/art/{{- .image -}}" title="{{.title}}" />
     </div>
@@ -31,6 +32,7 @@
         {{end}}
         </p>
     </div>
+    {{ end }}
     {{ end }}
     {{ if .Content }}
     <div class="content">


### PR DESCRIPTION
Update single layout for image-less pages like commission. This removes "see other artwork in" when it's not applicable.

Before:
<img width="888" height="392" alt="image" src="https://github.com/user-attachments/assets/ad73f55d-8695-418b-b66c-8ef238c3ca8d" />

After:
<img width="898" height="374" alt="image" src="https://github.com/user-attachments/assets/d0a8c97c-00d9-4c2f-89c9-957130dd8b15" />
