### PR TITLE
Support next/previous navigation across tags

### DIFF
--- a/themes/Malara/layouts/_default/single.html
+++ b/themes/Malara/layouts/_default/single.html
@@ -32,6 +32,36 @@
         {{end}}
         </p>
     </div>
+    {{ range .tags }}
+      {{ $tag := . }}
+      {{ $tagPages := index $.Site.Taxonomies.tags $tag }}
+      {{ $total := len $tagPages }}
+      {{ $prevURL := "" }}
+      {{ $nextURL := "" }}
+      {{ range $i, $wp := $tagPages }}
+        {{ if eq $wp.Page.RelPermalink $.RelPermalink }}
+          {{ if gt $i 0 }}
+            {{ $prevURL = printf "%s?from=%s" (index $tagPages (sub $i 1)).Page.Permalink $tag }}
+          {{ end }}
+          {{ if lt (add $i 1) $total }}
+            {{ $nextURL = printf "%s?from=%s" (index $tagPages (add $i 1)).Page.Permalink $tag }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
+      {{ if or $prevURL $nextURL }}
+      <nav class="tag-nav" data-tag="{{ $tag }}" hidden>
+        {{ if $prevURL }}<a href="{{ $prevURL }}">← prev</a>{{ end }}
+        {{ if $nextURL }}<a href="{{ $nextURL }}">next →</a>{{ end }}
+      </nav>
+      {{ end }}
+    {{ end }}
+    <script>
+      const from = new URLSearchParams(location.search).get('from');
+      if (from) {
+        const nav = document.querySelector('.tag-nav[data-tag="' + from + '"]');
+        if (nav) nav.removeAttribute('hidden');
+      }
+    </script>
     {{ end }}
     {{ end }}
     {{ if .Content }}

--- a/themes/Malara/layouts/_default/single.html
+++ b/themes/Malara/layouts/_default/single.html
@@ -4,11 +4,34 @@
     {{ if .image }}
     <div class="picture">
         <img src="/art/{{- .image -}}" title="{{.title}}" />
+        {{ range .tags }}
+          {{ $tag := . }}
+          {{ $tagPages := index $.Site.Taxonomies.tags $tag }}
+          {{ $total := len $tagPages }}
+          {{ $prevURL := "" }}
+          {{ $nextURL := "" }}
+          {{ range $i, $wp := $tagPages }}
+            {{ if eq $wp.Page.RelPermalink $.RelPermalink }}
+              {{ if gt $i 0 }}
+                {{ $prevURL = printf "%s?from=%s" (index $tagPages (sub $i 1)).Page.Permalink $tag }}
+              {{ end }}
+              {{ if lt (add $i 1) $total }}
+                {{ $nextURL = printf "%s?from=%s" (index $tagPages (add $i 1)).Page.Permalink $tag }}
+              {{ end }}
+            {{ end }}
+          {{ end }}
+          {{ if or $prevURL $nextURL }}
+          <nav class="tag-nav" data-tag="{{ $tag }}" hidden>
+            {{ if $prevURL }}<div class="prev"><a href="{{ $prevURL }}" aria-label="Previous"></a></div>{{ end }}
+            {{ if $nextURL }}<div class="next"><a href="{{ $nextURL }}" aria-label="Next"></a></div>{{ end }}
+          </nav>
+          {{ end }}
+        {{ end }}
     </div>
     <div class="description">
         <p class="title">{{.title}}</p>
         <p class="image-description">{{.description}}</p>
-        
+
         {{ if .sold }}
             <p class="image-sold">{{.sold}}</p>
         {{ end }}
@@ -16,7 +39,7 @@
         {{ if .availability }}
             <p class="image-availability"><a href="{{.availabilityLink}}" target="_blank">{{.availability}}</a></p>
         {{ end }}
-        
+
         {{ range .sets }}
             {{ $setName := . }}
             {{ with $.Site.GetPage (printf "/sets/%s" $setName) }}
@@ -32,29 +55,6 @@
         {{end}}
         </p>
     </div>
-    {{ range .tags }}
-      {{ $tag := . }}
-      {{ $tagPages := index $.Site.Taxonomies.tags $tag }}
-      {{ $total := len $tagPages }}
-      {{ $prevURL := "" }}
-      {{ $nextURL := "" }}
-      {{ range $i, $wp := $tagPages }}
-        {{ if eq $wp.Page.RelPermalink $.RelPermalink }}
-          {{ if gt $i 0 }}
-            {{ $prevURL = printf "%s?from=%s" (index $tagPages (sub $i 1)).Page.Permalink $tag }}
-          {{ end }}
-          {{ if lt (add $i 1) $total }}
-            {{ $nextURL = printf "%s?from=%s" (index $tagPages (add $i 1)).Page.Permalink $tag }}
-          {{ end }}
-        {{ end }}
-      {{ end }}
-      {{ if or $prevURL $nextURL }}
-      <nav class="tag-nav" data-tag="{{ $tag }}" hidden>
-        {{ if $prevURL }}<a href="{{ $prevURL }}">← prev</a>{{ end }}
-        {{ if $nextURL }}<a href="{{ $nextURL }}">next →</a>{{ end }}
-      </nav>
-      {{ end }}
-    {{ end }}
     <script>
       const from = new URLSearchParams(location.search).get('from');
       if (from) {

--- a/themes/Malara/layouts/_default/taxonomy.html
+++ b/themes/Malara/layouts/_default/taxonomy.html
@@ -15,7 +15,7 @@
         <article class="art">
             {{ with .Params }}
             <div class="picture">
-                <a href="{{ $link }}">
+                <a href="{{ $link }}?from={{ $.Data.Term }}">
                     <img src="/thumbnails/{{- .image -}}" title="{{.title}}" />
                 </a>
             </div>

--- a/themes/Malara/layouts/index.html
+++ b/themes/Malara/layouts/index.html
@@ -17,7 +17,7 @@
             <article class="art">
                 {{ with .Params }}
                 <div class="picture">
-                    <a href="{{ $link }}">
+                    <a href="{{ $link }}?from=featured">
                         <img src="/thumbnails/{{- .image -}}" title="{{.title}}" />
                     </a>
                 </div>

--- a/themes/Malara/static/css/malara.css
+++ b/themes/Malara/static/css/malara.css
@@ -400,6 +400,77 @@ and (device-width: 360px) */
     max-height: 100%;
 }
 
+#single .picture {
+    position: relative;
+    display: inline-block;
+}
+
+.tag-nav {
+    position: absolute;
+    inset: 0;
+    display: flex;
+}
+
+.tag-nav .prev,
+.tag-nav .next {
+    display: flex;
+    align-items: center;
+    padding: 1em;
+}
+
+.tag-nav .prev {
+    width: 20%;
+}
+
+.tag-nav .next {
+    flex: 1;
+}
+
+.tag-nav .prev a,
+.tag-nav .next a {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    text-decoration: none;
+    user-select: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+
+.tag-nav .prev a {
+    justify-content: flex-start;
+}
+
+.tag-nav .next a {
+    justify-content: flex-end;
+}
+
+.tag-nav .prev a::before,
+.tag-nav .next a::before {
+    content: '';
+    display: block;
+    width: 22px;
+    height: 22px;
+    border-top: 3px solid white;
+    filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.8));
+}
+
+.tag-nav .prev a::before {
+    border-left: 3px solid white;
+    transform: rotate(-45deg);
+}
+
+.tag-nav .next a::before {
+    border-right: 3px solid white;
+    transform: rotate(45deg);
+}
+
+#single .picture:hover .tag-nav .prev a,
+#single .picture:hover .tag-nav .next a {
+    opacity: 1;
+}
+
 /* --- Front page specific --- */
 
 #homepage-content {

--- a/themes/Malara/static/css/malara.css
+++ b/themes/Malara/static/css/malara.css
@@ -405,7 +405,7 @@ and (device-width: 360px) */
     display: inline-block;
 }
 
-.tag-nav {
+.tag-nav:not([hidden]) {
     position: absolute;
     inset: 0;
     display: flex;


### PR DESCRIPTION
Since Hugo does not support navigation through taxonomy, work around this by
- when opening an image, append URL query parameter indicating which tag you came from
- creating a next/prev navigation for each available taxonomy
- show only the navigation that's applicable given the new URL query parameter
